### PR TITLE
Make arrow point to the right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -149,6 +149,8 @@ const CollapseMenuItem = styled(MenuItemButton)`
 
   @media (min-width: ${breakpoint("desktop")}) {
     display: flex;
+    transform: ${({ isCollapsed }) =>
+      isCollapsed ? "rotate(180deg)" : "rotate(0)"};
   }
 `;
 


### PR DESCRIPTION
Make sure that when the sidebar navigation is collapsed the arrow of the “Collapse” button points to the right.