### PR TITLE
Fix text color of page info at bottom of issue list

### DIFF
--- a/features/issues/components/issue-list/issue-list.tsx
+++ b/features/issues/components/issue-list/issue-list.tsx
@@ -54,7 +54,7 @@ const PaginationButton = styled.button`
 `;
 
 const PageInfo = styled.div`
-  color: ${color("gray", 300)};
+  color: ${color("gray", 700)};
   ${textFont("sm", "regular")}
 `;
 


### PR DESCRIPTION
Make the text color of page info at the bottom of the issue list have more contrast so it's readable. 
