### PR TITLE
Make support button open users email app

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -32,13 +32,14 @@ describe("Sidebar Navigation", () => {
     });
 
     it("opens the user's email app", () => {
-      cy.get("nav")
-        .contains("Support")
-        .invoke("on", "click", (e: { preventDefault: () => void }) => {
-          console.log("stop the default browser behavior");
-          e.preventDefault();
-        })
-        .click();
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("open");
+      });
+      cy.get("nav").contains("Support").click();
+      cy.get("@open").should(
+        "have.been.calledOnceWithExactly",
+        "mailto:support@prolog-app.com?subject=Support%20Request"
+      );
     });
 
     it("is collapsible", () => {

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -32,7 +32,13 @@ describe("Sidebar Navigation", () => {
     });
 
     it("opens the user's email app", () => {
-      cy.get("nav").contains("Support").invoke("removeAttr", "target").click();
+      cy.get("nav")
+        .contains("Support")
+        .invoke("on", "click", (e: { preventDefault: () => void }) => {
+          console.log("stop the default browser behavior");
+          e.preventDefault();
+        })
+        .click();
     });
 
     it("is collapsible", () => {

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -31,6 +31,10 @@ describe("Sidebar Navigation", () => {
         .should("have.attr", "href", "/dashboard/settings");
     });
 
+    it("opens the user's email app", () => {
+      cy.get("nav").contains("Support").click();
+    });
+
     it("is collapsible", () => {
       // collapse navigation
       cy.get("nav").contains("Collapse").click();

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -32,7 +32,7 @@ describe("Sidebar Navigation", () => {
     });
 
     it("opens the user's email app", () => {
-      cy.get("nav").contains("Support").click();
+      cy.get("nav").contains("Support").invoke("removeAttr", "target").click();
     });
 
     it("is collapsible", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -195,7 +195,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support%20Request"
+                )
+              }
             />
             <CollapseMenuItem
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -197,8 +197,7 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() =>
                 window.open(
-                  "mailto:support@prolog-app.com?subject=Support%20Request",
-                  "_blank"
+                  "mailto:support@prolog-app.com?subject=Support%20Request"
                 )
               }
             />

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -158,6 +158,12 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const openEmail = () => {
+    window.location.href =
+      "mailto:support@prolog-app.com?subject=Support%20Request";
+  };
+
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
@@ -195,12 +201,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() =>
-                window.open(
-                  "mailto:support@prolog-app.com?subject=Support%20Request",
-                  "_blank"
-                )
-              }
+              onClick={openEmail}
             />
             <CollapseMenuItem
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -197,7 +197,8 @@ export function SidebarNavigation() {
               isCollapsed={isSidebarCollapsed}
               onClick={() =>
                 window.open(
-                  "mailto:support@prolog-app.com?subject=Support%20Request"
+                  "mailto:support@prolog-app.com?subject=Support%20Request",
+                  "_blank"
                 )
               }
             />

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -158,12 +158,6 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  const openEmail = () => {
-    window.location.href =
-      "mailto:support@prolog-app.com?subject=Support%20Request";
-  };
-
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
@@ -201,7 +195,12 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={openEmail}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support%20Request",
+                  "_blank"
+                )
+              }
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
Clicking the “Support” button in the sidebar navigation opens the user’s email app.

