### PR TITLE
Add all navigation items at the top of the landing page

### DIFF
--- a/config/routes.tsx
+++ b/config/routes.tsx
@@ -1,5 +1,8 @@
 export const Routes = {
   home: "/",
+  products: "/products",
+  documentation: "/documentation",
+  pricing: "/pricing",
   projects: "/dashboard/",
   issues: "/dashboard/issues",
   alerts: "/dashboard/alerts",

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -12,6 +12,25 @@ const Header = styled.header`
   background: white;
 `;
 
+const Navigation = styled.nav`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+`;
+
+const NavigationButton = styled.a`
+  background: none;
+  color: #667085;
+  text-decoration: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+`;
+
 const ContactButton = styled.button`
   position: absolute;
   bottom: 2.5rem;
@@ -28,13 +47,37 @@ const ContactButton = styled.button`
   }
 `;
 
+const DashboardButton = styled.a`
+  height: 44px;
+  width: 165px;
+  border-radius: 8px;
+  background-color: #7556d9;
+  color: #fff;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 24px;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const IssuesPage = () => {
   return (
     <div>
       <Header>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/icons/logo-large.svg" alt="Prolog logo" />
-        <a href={Routes.projects}>Dashboard</a>
+        <Navigation>
+          <NavigationButton href={Routes.home}>Home</NavigationButton>
+          <NavigationButton href={Routes.products}>Products</NavigationButton>
+          <NavigationButton href={Routes.documentation}>
+            Documentation
+          </NavigationButton>
+          <NavigationButton href={Routes.pricing}>Prices</NavigationButton>
+        </Navigation>
+        <DashboardButton href={Routes.projects}>Open Dashboard</DashboardButton>
       </Header>
       <ContactButton
         onClick={() =>


### PR DESCRIPTION
Display all navigation items at the top of the page so that users can quickly navigate to the most important pages.